### PR TITLE
add Locker support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/graxinc/kmutex
 
-go 1.23
+go 1.24
 
 require (
 	github.com/graxinc/syncmap v0.0.0-20241016221111-1f2c2c6f98d1

--- a/kmutex.go
+++ b/kmutex.go
@@ -6,13 +6,47 @@ import (
 	"github.com/graxinc/syncmap"
 )
 
+// Must compare equal per instance.
+type Locker interface {
+	Lock()
+	Unlock()
+}
+
+type SemaLocker struct {
+	ch chan struct{}
+}
+
+// n must be > 0.
+func NewSemaLocker(n int) SemaLocker {
+	if n <= 0 {
+		panic("kmutex: sema locker n <= 0")
+	}
+	return SemaLocker{make(chan struct{}, n)}
+}
+
+func (l SemaLocker) Lock() {
+	l.ch <- struct{}{}
+}
+
+func (l SemaLocker) Unlock() {
+	<-l.ch
+}
+
 // Concurrent safe.
 type KMutex[T comparable] struct {
-	m syncmap.Map[T, *sync.Mutex]
+	m         syncmap.Map[T, Locker]
+	newLocker func() Locker
 }
 
 func New[T comparable]() *KMutex[T] {
-	return &KMutex[T]{}
+	l := func() Locker {
+		return &sync.Mutex{}
+	}
+	return NewLocker[T](l)
+}
+
+func NewLocker[T comparable](newLocker func() Locker) *KMutex[T] {
+	return &KMutex[T]{newLocker: newLocker}
 }
 
 // Takes an exclusive lock for key.
@@ -21,9 +55,9 @@ func (km *KMutex[T]) Lock(key T) (unlock func()) {
 	// Some overhead here on the atomic ops in the Map,
 	// but the goal is low contention when most Lock(key)
 	// are with unique keys. Shared keys will contend anyways
-	// on their lock, since that is the point of KMutex.
+	// on their underlying, since that is the point.
 	for {
-		mu, _ := km.m.LoadOrStore(key, &sync.Mutex{})
+		mu, _ := km.m.LoadOrStore(key, km.newLocker())
 		mu.Lock()
 
 		// For !ok case, Delete will happen before this Lock.

--- a/kmutex_test.go
+++ b/kmutex_test.go
@@ -17,34 +17,69 @@ type kmutexer interface {
 }
 
 func TestKmutex(t *testing.T) {
-	km := kmutex.New[int]()
+	t.Parallel()
 
-	resources := make([]int, 10)
+	do := func(km *kmutex.KMutex[int]) {
+		resources := make([]int, 10)
 
-	var wg sync.WaitGroup
-	for i := 0; i < 100; i++ {
-		i := i
+		var wg sync.WaitGroup
+		for i := range 100 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+				rando := rand.New(rand.NewSource(int64(i))) //nolint:gosec
 
-			rando := rand.New(rand.NewSource(int64(i))) //nolint:gosec
+				for range 1000 {
+					idx := rando.Intn(len(resources))
 
-			for j := 0; j < 1000; j++ {
-				idx := rando.Intn(len(resources))
+					// Relies on Go race detector being enabled.
+					unlock := km.Lock(idx)
+					resources[idx] = resources[idx] + 1
+					unlock()
+				}
+			}()
+		}
+		wg.Wait()
 
-				// Relies on Go race detector being enabled.
-				unlock := km.Lock(idx)
-				resources[idx] = resources[idx] + 1
-				unlock()
-			}
-		}()
+		for i := range resources {
+			km.Lock(i)
+		}
 	}
-	wg.Wait()
+	t.Run("mu", func(t *testing.T) {
+		do(kmutex.New[int]())
+	})
+	t.Run("sema_1", func(t *testing.T) {
+		km := kmutex.NewLocker[int](func() kmutex.Locker {
+			return kmutex.NewSemaLocker(1)
+		})
+		do(km)
+	})
+}
 
-	for i := range resources {
-		km.Lock(i)
+func TestSemaLocker_equal(t *testing.T) {
+	t.Parallel()
+
+	equalFatal := func(a, b kmutex.Locker) {
+		t.Helper()
+		if a != b {
+			t.Fatal("not equal")
+		}
+	}
+
+	s1 := kmutex.NewSemaLocker(1)
+	s2 := kmutex.NewSemaLocker(1)
+	s3 := kmutex.NewSemaLocker(2)
+
+	equalFatal(s1, s1)
+	equalFatal(s2, s2)
+	equalFatal(s3, s3)
+
+	if s1 == s2 {
+		t.Fatal("should not be equal")
+	}
+	if s1 == s3 {
+		t.Fatal("should not be equal")
 	}
 }
 
@@ -54,15 +89,14 @@ func BenchmarkKMutex_uniqueKeys(b *testing.B) {
 
 		do := func() {
 			var wg sync.WaitGroup
-			for i := 0; i < 100; i++ {
-				i := i
+			for i := range 100 {
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
 
 					rando := rand.New(rand.NewSource(int64(i))) //nolint:gosec
 
-					for j := 0; j < 1000; j++ {
+					for range 1000 {
 						idx := rando.Intn(100)
 
 						unlock := km.Lock(idx)
@@ -74,13 +108,19 @@ func BenchmarkKMutex_uniqueKeys(b *testing.B) {
 			wg.Wait()
 		}
 
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			do()
 		}
 	}
 
-	b.Run("grax", func(b *testing.B) {
+	b.Run("grax mu", func(b *testing.B) {
 		km := kmutex.New[int]()
+		do(b, km)
+	})
+	b.Run("grax sema 2", func(b *testing.B) {
+		km := kmutex.NewLocker[int](func() kmutex.Locker {
+			return kmutex.NewSemaLocker(2)
+		})
 		do(b, km)
 	})
 	b.Run("immortal", func(b *testing.B) {


### PR DESCRIPTION
This can allow locking for each key, where the key's lock is a semaphore.

Benchmark (with profiler commented out):
```
BenchmarkKMutex_uniqueKeys
BenchmarkKMutex_uniqueKeys/grax_mu
BenchmarkKMutex_uniqueKeys/grax_mu-8         	      20	 104068229 ns/op
BenchmarkKMutex_uniqueKeys/grax_sema_2
BenchmarkKMutex_uniqueKeys/grax_sema_2-8     	      20	 120521967 ns/op
BenchmarkKMutex_uniqueKeys/immortal
BenchmarkKMutex_uniqueKeys/immortal-8        	      20	 125882290 ns/op
PASS
```